### PR TITLE
creates ranges(toc) as prezi 2.0

### DIFF
--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-
 from lxml import etree
 import json, sys, re
 import urllib2
@@ -254,6 +253,62 @@ def create_ranges(ranges, previous_id, manifest_uri):
 		create_range_json(new_ranges, manifest_uri, range_id, previous_id, label)
 		create_ranges(new_ranges, range_id, manifest_uri)
 
+
+###################
+#
+# changes to create a prezi 2.0 table of contents
+#
+def translate_range(range_dict, prefix, manifest_uri):
+
+    # assume it's a dict, and it has only one item
+    k = list(range_dict.keys())[0]
+    v = range_dict[k]
+    parent_range = {
+        '@id': '{0}/range/range-{1}.json'.format(manifest_uri, prefix),
+        '@type': 'sc:Range',
+        'label': k,
+        'canvases': [],
+        'ranges': [],
+    }
+    range_list = [parent_range]
+
+    if isinstance(v, str):  # one canvas
+        parent_range['canvases'].append('{0}/canvas/canvas-{1}.json'.format(
+            manifest_uri, v))
+
+    if isinstance(v, list): # v might be list of canvases or nested ranges
+        for i, item in enumerate(v):  # assume v it's a list of str or dicts
+            new_prefix = '{}-{}'.format(prefix, i)
+            child_range, r_list = translate_range(item, new_prefix, manifest_uri)
+            parent_range['ranges'].append(child_range['@id'])
+            range_list += r_list
+
+    # remove empty lists
+    if not parent_range['canvases']:
+        del parent_range['canvases']
+    if not parent_range['ranges']:
+        del parent_range['ranges']
+    return parent_range, range_list
+
+
+def translate_ranges(mets_ranges, manifest_uri):
+    """
+    returns list of iiif ranges
+
+    mets_ranges: list of one dict
+    manifest_uri: includes protocol://hostname:port/path_prefix
+    """
+    parent_range, child_range = translate_range(mets_ranges[0], '0', manifest_uri)
+    toc = child_range[0]
+    # per iiif prezi 2.0, table of contents should have viewingHint
+    toc['viewingHint'] = 'top'
+    return child_range
+#
+# changes to create a prezi 2.0 table of contents
+#
+###################
+
+
 def main(data, document_id, source, host, cookie=None):
 
 	# clear global variables
@@ -397,10 +452,16 @@ def main(data, document_id, source, host, cookie=None):
 		canvases.append(cvsjson)
 
 	# build table of contents using Range and Structures
-	create_ranges(rangeInfo, manifest_uri, manifest_uri)
+	###########
+	# change for prezi 2.0 table of contents
+	#create_ranges(rangeInfo, manifest_uri, manifest_uri)
+	iiif2_toc = translate_ranges(rangeInfo, manifest_uri)
 
 	mfjson['sequences'][0]['canvases'] = canvases
-	mfjson['structures'] = rangesJsonList
+	#mfjson['structures'] = rangesJsonList
+	mfjson['structures'] = iiif2_toc
+	# change for prezi 2.0 table of contents
+	###########
 
 	output = json.dumps(mfjson, indent=4, sort_keys=True)
 	return output


### PR DESCRIPTION
i was able to test but in a more decoupled env in:
https://github.com/nmaekawa/mets2iiif

i've mocked a bunch of things and had only the parts that matter to table-of-contents working. The resulting manifest passes the iiif validator (so it's syntactically correct), but i don't think the validator can catch when the toc is flipped (as in press 1.0) or not...

the id's for each range are not sequential anymore, and i wonder if this matters. I ended up compounding the list position with the level of nesting in the dicts to have a unique id per manifest.
