### PR TITLE
Libdrs 8313 -iiif wont render objects w/ toc

### DIFF
--- a/manifests/__init__.py
+++ b/manifests/__init__.py
@@ -1,2 +1,0 @@
-# For relative imports to work in Python 3.6 - used to test mets.py
-import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/manifests/__init__.py
+++ b/manifests/__init__.py
@@ -1,0 +1,2 @@
+# For relative imports to work in Python 3.6 - used to test mets.py
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -163,22 +163,22 @@ def process_intermediate(div, instance_var, new_ranges=None):
                 if is_page(sd):
                         my_range = process_page(sd, instance_var)
                 else:
-			#logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
+			logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
                         my_range = process_intermediate(sd, instance_var)
-			#logger.debug("process_intermediate: my_range: " + str(my_range) )
+			logger.debug("process_intermediate: my_range: " + str(my_range) )
                 if my_range:
-			#logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
+			logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
                         new_ranges.append(my_range)
 
         # this is for the books where every single page is labeled (like Book of Hours)
         # most books do not do this
         if len(new_ranges) == 1:
-		#logger.debug("process_intermediate: returning a new_range w/ len 1")
+		logger.debug("process_intermediate: returning a new_range w/ len 1")
                 return {get_rangeKey(div): new_ranges[0].values()[0]}
 
         #rkey = get_rangeKey(div)
-	#logger.debug("process_intermediate: returning ranges for int div: " + div.get('LABEL') + " new_ranges size: " + str(len(new_ranges))  + " range key: " + rkey)
-	#logger.debug("process_intermediate: new_ranges: " + str(new_ranges) )
+	logger.debug("process_intermediate: returning ranges for int div: " + div.get('LABEL') + " new_ranges size: " + str(len(new_ranges))  + " range key: " + rkey)
+	logger.debug("process_intermediate: new_ranges: " + str(new_ranges) )
         return {get_rangeKey(div): new_ranges}
 
 
@@ -206,7 +206,7 @@ def get_intermediate_seq_values(first, last):
 
         if last.get('TYPE') == 'PAGE':
                 last_vals = {"seq": last.get('ORDER'), "page": page_num(last)}
-
+		logger.debug("get intermediate seq vals: " + first_vals + " " + last_vals)
         return first_vals, last_vals
 
 def process_struct_divs(div, ranges, ivar):
@@ -223,7 +223,7 @@ def process_struct_divs(div, ranges, ivar):
 			if len(subdivs) > 0:
 				ranges.append(process_intermediate(div, ivar))
 
-	#logger.debug("process_st_divs: ranges: " + str(ranges) ) 
+	logger.debug("process_st_divs: ranges: " + str(ranges) ) 
 	return ranges
 
 def process_structMap(smap):
@@ -318,22 +318,22 @@ def main(data, document_id, source, host, cookie=None):
                    drs2json['object_structmap_raw'] + settings.METS_FOOTER
 
 
-	#logger.debug("LOADING object " + str(document_id) + " into the DOM tree" )
+	logger.debug("LOADING object " + str(document_id) + " into the DOM tree" )
 	data = re.sub('(?i)encoding=[\'\"]utf\-8[\'\"]','', data)
 	utf8_parser = etree.XMLParser(encoding='utf-8')
 	dom = etree.XML(data, parser=utf8_parser)
-	#logger.debug("object " + str(document_id) + " LOADED into the DOM tree" )
+	logger.debug("object " + str(document_id) + " LOADED into the DOM tree" )
 	# Check if this is a DRS2 object since some things, like hollis ID are in a different location
 
-	#logger.debug("dom check: mets label candidates..." )
+	logger.debug("dom check: mets label candidates..." )
 	mets_label_candidates = dom.xpath('/mets:mets/@LABEL', namespaces=XMLNS)
-	#logger.debug("dom check: mets label candidates found" )
+	logger.debug("dom check: mets label candidates found" )
 	if (len(mets_label_candidates) > 0) and (mets_label_candidates[0] != ""):
 		manifestLabel = mets_label_candidates[0]
 	else:
-		#logger.debug("dom check: title candidates...")
+		logger.debug("dom check: title candidates...")
 		mods_title_candidates = dom.xpath('//mods:mods/mods:titleInfo/mods:title', namespaces=XMLNS)
-		#logger.debug("dom check: title candidates found")
+		logger.debug("dom check: title candidates found")
 		if len(mods_title_candidates) > 0:
 			manifestLabel = mods_title_candidates[0].text
 		else:
@@ -401,9 +401,9 @@ def main(data, document_id, source, host, cookie=None):
 				manifestLabel = manifestLabel + "."
 
 	
-	#logger.debug("dom check: manifest types check..." )
+	logger.debug("dom check: manifest types check..." )
 	manifestType = dom.xpath('/mets:mets/@TYPE', namespaces=XMLNS)[0]
-	#logger.debug("dom check: manifest type found" )
+	logger.debug("dom check: manifest type found" )
 
 	if manifestType in ["PAGEDOBJECT", "PDS DOCUMENT"]:
 		viewingHint = "paged"
@@ -417,7 +417,7 @@ def main(data, document_id, source, host, cookie=None):
 	viewingDirection = 'left-to-right' # default
 	seeAlso = u""
 
-	#logger.debug("dom check: hollis check..." )
+	logger.debug("dom check: hollis check..." )
 	hollisCheck = dom.xpath('/mets:mets/mets:amdSec/mets:techMD/mets:mdWrap/mets:xmlData/hulDrsAdmin:hulDrsAdmin/hulDrsAdmin:drsObject/hulDrsAdmin:harvardMetadataLinks/hulDrsAdmin:metadataIdentifier[../hulDrsAdmin:metadataType/text()="Aleph"]/text()', namespaces=XMLNS)
 
 	if len(hollisCheck) > 0:
@@ -442,10 +442,10 @@ def main(data, document_id, source, host, cookie=None):
 
 	manifest_uri = manifestUriBase + "%s:%s" % (source, document_id)
 
-	#logger.debug("dom check: images and structs..." )
+	logger.debug("dom check: images and structs..." )
 	images = dom.xpath('/mets:mets/mets:fileSec/mets:fileGrp/mets:file[starts-with(@MIMETYPE, "image/")]', namespaces=XMLNS)
 	struct = dom.xpath('/mets:mets/mets:structMap/mets:div[@TYPE="CITATION"]/mets:div', namespaces=XMLNS)
-	#logger.debug("dom check: images and structs found." )
+	logger.debug("dom check: images and structs found." )
 
 	# Check if the object has a stitched version(s) already made.  Use only those
 	# this has been intentionally removed to show full drs structure instead -cg
@@ -630,9 +630,9 @@ def main(data, document_id, source, host, cookie=None):
 	mfjson['sequences'][0]['canvases'] = canvases
 	mfjson['structures'] = iiif2_toc
 
-	#logger.debug("Dumping json for DRS2 object " + str(document_id) )
+	logger.debug("Dumping json for DRS2 object " + str(document_id) )
 	output = json.dumps(mfjson, indent=4, sort_keys=True)
-	#logger.debug("Dumping complete for DRS2 object " + str(document_id) )
+	logger.debug("Dumping complete for DRS2 object " + str(document_id) )
 	instVar = None
 	return output
 

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -324,7 +324,7 @@ def main(data, document_id, source, host, cookie=None):
 	data = re.sub('(?i)encoding=[\'\"]utf\-8[\'\"]','', data)
 	utf8_parser = etree.XMLParser(encoding='utf-8')
 	dom = etree.XML(data, parser=utf8_parser)
-	logger.debug("object " + str(document_id) + " LOADED into the DOM tree" )
+	#logger.debug("object " + str(document_id) + " LOADED into the DOM tree" )
 	# Check if this is a DRS2 object since some things, like hollis ID are in a different location
 
 	#logger.debug("dom check: mets label candidates..." )

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -163,22 +163,22 @@ def process_intermediate(div, instance_var, new_ranges=None):
                 if is_page(sd):
                         my_range = process_page(sd, instance_var)
                 else:
-			logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
+						#logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
                         my_range = process_intermediate(sd, instance_var)
-			logger.debug("process_intermediate: my_range: " + str(my_range) )
+						#logger.debug("process_intermediate: my_range: " + str(my_range) )
                 if my_range:
-			logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
+						#logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
                         new_ranges.append(my_range)
 
         # this is for the books where every single page is labeled (like Book of Hours)
         # most books do not do this
         if len(new_ranges) == 1:
-		logger.debug("process_intermediate: returning a new_range w/ len 1")
+				#logger.debug("process_intermediate: returning a new_range w/ len 1")
                 return {get_rangeKey(div): new_ranges[0].values()[0]}
 
         #rkey = get_rangeKey(div)
-	logger.debug("process_intermediate: returning ranges for int div: " + div.get('LABEL') + " new_ranges size: " + str(len(new_ranges))  + " range key: " + rkey)
-	logger.debug("process_intermediate: new_ranges: " + str(new_ranges) )
+		#logger.debug("process_intermediate: returning ranges for int div: " + div.get('LABEL') + " new_ranges size: " + str(len(new_ranges))  + " range key: " + rkey)
+		#logger.debug("process_intermediate: new_ranges: " + str(new_ranges) )
         return {get_rangeKey(div): new_ranges}
 
 
@@ -206,7 +206,7 @@ def get_intermediate_seq_values(first, last):
 
         if last.get('TYPE') == 'PAGE':
                 last_vals = {"seq": last.get('ORDER'), "page": page_num(last)}
-		logger.debug("get intermediate seq vals: " + first_vals + " " + last_vals)
+        logger.debug("get intermediate seq vals: " + first_vals + " " + last_vals)
         return first_vals, last_vals
 
 def process_struct_divs(div, ranges, ivar):

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -165,15 +165,15 @@ def process_intermediate(div, instance_var, new_ranges=None):
                 else:
                         logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
                         my_range = process_intermediate(sd, instance_var)
-						#logger.debug("process_intermediate: my_range: " + str(my_range) )
+                        logger.debug("process_intermediate: my_range: " + str(my_range) )
                 if my_range:
-						#logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
+                        logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
                         new_ranges.append(my_range)
 
         # this is for the books where every single page is labeled (like Book of Hours)
         # most books do not do this
         if len(new_ranges) == 1:
-				#logger.debug("process_intermediate: returning a new_range w/ len 1")
+                logger.debug("process_intermediate: returning a new_range w/ len 1, div: " + div.get('LABEL') )
                 return {get_rangeKey(div): list(new_ranges[0].values())[0]}
 
         #rkey = get_rangeKey(div)

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -163,15 +163,16 @@ def process_intermediate(div, instance_var, new_ranges=None):
                 if is_page(sd):
                         my_range = process_page(sd, instance_var)
                 else:
-                        logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
+                        #logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
                         my_range = process_intermediate(sd, instance_var)
-                        logger.debug("process_intermediate: my_range: " + str(my_range) )
+                        #logger.debug("process_intermediate: my_range: " + str(my_range) )
                 if my_range:
-                        logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
+                        #logger.debug("process_intermediate: appending ranges for int div: " + div.get('LABEL') + " range: " + str(my_range) )
                         new_ranges.append(my_range)
 
         # this is for the books where every single page is labeled (like Book of Hours)
         # most books do not do this
+		#### 1/6/2021 cg- this breaks nested labels! - problematic
         #if len(new_ranges) == 1:
                 #logger.debug("process_intermediate: returning a new_range w/ len 1, div: " + div.get('LABEL') )
                 #return {get_rangeKey(div): list(new_ranges[0].values())[0]}
@@ -224,7 +225,7 @@ def process_struct_divs(div, ranges, ivar):
 		if len(subdivs) > 0:
 			ranges.append(process_intermediate(div, ivar))
 
-	logger.debug("process_st_divs: ranges: " + str(ranges) ) 
+	#logger.debug("process_st_divs: ranges: " + str(ranges) ) 
 	return ranges
 
 def process_structMap(smap):
@@ -319,22 +320,22 @@ def main(data, document_id, source, host, cookie=None):
                    drs2json['object_structmap_raw'] + settings.METS_FOOTER
 
 
-	logger.debug("LOADING object " + str(document_id) + " into the DOM tree" )
+	#logger.debug("LOADING object " + str(document_id) + " into the DOM tree" )
 	data = re.sub('(?i)encoding=[\'\"]utf\-8[\'\"]','', data)
 	utf8_parser = etree.XMLParser(encoding='utf-8')
 	dom = etree.XML(data, parser=utf8_parser)
 	logger.debug("object " + str(document_id) + " LOADED into the DOM tree" )
 	# Check if this is a DRS2 object since some things, like hollis ID are in a different location
 
-	logger.debug("dom check: mets label candidates..." )
+	#logger.debug("dom check: mets label candidates..." )
 	mets_label_candidates = dom.xpath('/mets:mets/@LABEL', namespaces=XMLNS)
-	logger.debug("dom check: mets label candidates found" )
+	#logger.debug("dom check: mets label candidates found" )
 	if (len(mets_label_candidates) > 0) and (mets_label_candidates[0] != ""):
 		manifestLabel = mets_label_candidates[0]
 	else:
-		logger.debug("dom check: title candidates...")
+		#logger.debug("dom check: title candidates...")
 		mods_title_candidates = dom.xpath('//mods:mods/mods:titleInfo/mods:title', namespaces=XMLNS)
-		logger.debug("dom check: title candidates found")
+		#logger.debug("dom check: title candidates found")
 		if len(mods_title_candidates) > 0:
 			manifestLabel = mods_title_candidates[0].text
 		else:
@@ -402,9 +403,9 @@ def main(data, document_id, source, host, cookie=None):
 				manifestLabel = manifestLabel + "."
 
 	
-	logger.debug("dom check: manifest types check..." )
+	#logger.debug("dom check: manifest types check..." )
 	manifestType = dom.xpath('/mets:mets/@TYPE', namespaces=XMLNS)[0]
-	logger.debug("dom check: manifest type found" )
+	#logger.debug("dom check: manifest type found" )
 
 	if manifestType in ["PAGEDOBJECT", "PDS DOCUMENT"]:
 		viewingHint = "paged"
@@ -418,7 +419,7 @@ def main(data, document_id, source, host, cookie=None):
 	viewingDirection = 'left-to-right' # default
 	seeAlso = u""
 
-	logger.debug("dom check: hollis check..." )
+	#logger.debug("dom check: hollis check..." )
 	hollisCheck = dom.xpath('/mets:mets/mets:amdSec/mets:techMD/mets:mdWrap/mets:xmlData/hulDrsAdmin:hulDrsAdmin/hulDrsAdmin:drsObject/hulDrsAdmin:harvardMetadataLinks/hulDrsAdmin:metadataIdentifier[../hulDrsAdmin:metadataType/text()="Aleph"]/text()', namespaces=XMLNS)
 
 	if len(hollisCheck) > 0:
@@ -443,10 +444,10 @@ def main(data, document_id, source, host, cookie=None):
 
 	manifest_uri = manifestUriBase + "%s:%s" % (source, document_id)
 
-	logger.debug("dom check: images and structs..." )
+	#logger.debug("dom check: images and structs..." )
 	images = dom.xpath('/mets:mets/mets:fileSec/mets:fileGrp/mets:file[starts-with(@MIMETYPE, "image/")]', namespaces=XMLNS)
 	struct = dom.xpath('/mets:mets/mets:structMap/mets:div[@TYPE="CITATION"]/mets:div', namespaces=XMLNS)
-	logger.debug("dom check: images and structs found." )
+	#logger.debug("dom check: images and structs found." )
 
 	# Check if the object has a stitched version(s) already made.  Use only those
 	# this has been intentionally removed to show full drs structure instead -cg
@@ -631,9 +632,9 @@ def main(data, document_id, source, host, cookie=None):
 	mfjson['sequences'][0]['canvases'] = canvases
 	mfjson['structures'] = iiif2_toc
 
-	logger.debug("Dumping json for DRS2 object " + str(document_id) )
+	#logger.debug("Dumping json for DRS2 object " + str(document_id) )
 	output = json.dumps(mfjson, indent=4, sort_keys=True)
-	logger.debug("Dumping complete for DRS2 object " + str(document_id) )
+	#logger.debug("Dumping complete for DRS2 object " + str(document_id) )
 	instVar = None
 	return output
 

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -163,7 +163,7 @@ def process_intermediate(div, instance_var, new_ranges=None):
                 if is_page(sd):
                         my_range = process_page(sd, instance_var)
                 else:
-						#logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
+                        logger.debug("process_intermediate: processing int div: " + div.get('LABEL') )
                         my_range = process_intermediate(sd, instance_var)
 						#logger.debug("process_intermediate: my_range: " + str(my_range) )
                 if my_range:

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -172,9 +172,9 @@ def process_intermediate(div, instance_var, new_ranges=None):
 
         # this is for the books where every single page is labeled (like Book of Hours)
         # most books do not do this
-        if len(new_ranges) == 1:
-                logger.debug("process_intermediate: returning a new_range w/ len 1, div: " + div.get('LABEL') )
-                return {get_rangeKey(div): list(new_ranges[0].values())[0]}
+        #if len(new_ranges) == 1:
+                #logger.debug("process_intermediate: returning a new_range w/ len 1, div: " + div.get('LABEL') )
+                #return {get_rangeKey(div): list(new_ranges[0].values())[0]}
 
         #rkey = get_rangeKey(div)
 		#logger.debug("process_intermediate: returning ranges for int div: " + div.get('LABEL') + " new_ranges size: " + str(len(new_ranges))  + " range key: " + rkey)

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -174,7 +174,7 @@ def process_intermediate(div, instance_var, new_ranges=None):
         # most books do not do this
         if len(new_ranges) == 1:
 				#logger.debug("process_intermediate: returning a new_range w/ len 1")
-                return {get_rangeKey(div): new_ranges[0].values()[0]}
+                return {get_rangeKey(div): list(new_ranges[0].values())[0]}
 
         #rkey = get_rangeKey(div)
 		#logger.debug("process_intermediate: returning ranges for int div: " + div.get('LABEL') + " new_ranges size: " + str(len(new_ranges))  + " range key: " + rkey)

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -206,7 +206,8 @@ def get_intermediate_seq_values(first, last):
 
         if last.get('TYPE') == 'PAGE':
                 last_vals = {"seq": last.get('ORDER'), "page": page_num(last)}
-        logger.debug("get intermediate seq vals: " + first_vals + " " + last_vals)
+        
+		#logger.debug("get intermediate seq vals: " + first_vals + " " + last_vals)
         return first_vals, last_vals
 
 def process_struct_divs(div, ranges, ivar):

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -219,10 +219,10 @@ def process_struct_divs(div, ranges, ivar):
 		p_range = process_page(div, ivar)
 		if p_range: 
 			ranges.append(p_range)
-		else:
-			subdivs = div.xpath('./mets:div', namespaces = XMLNS)
-			if len(subdivs) > 0:
-				ranges.append(process_intermediate(div, ivar))
+	else:
+		subdivs = div.xpath('./mets:div', namespaces = XMLNS)
+		if len(subdivs) > 0:
+			ranges.append(process_intermediate(div, ivar))
 
 	logger.debug("process_st_divs: ranges: " + str(ranges) ) 
 	return ranges

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -162,7 +162,6 @@ def view(request, view_type, document_id):
 		else:
 			mfwobject = {"loadedManifest": uri,
 				"viewType": parts["view"] }
-				
 			if view_type == "view-dev": #mirador 3 preview
 			  mfwobject = {"loadedManifest": uri,
 						   "thumbnailNavigationPosition": "far-bottom"}

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -39,6 +39,7 @@ sources = {"drs": "mets", "via": "mods", "hollis": "mods", "huam" : "huam", "ext
 
 def index(request, source=None):
 	request_ip = request.META['REMOTE_ADDR']
+	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)
@@ -243,8 +244,7 @@ def manifest(request, document_id):
 # Delete any document from db
 def delete(request, document_id):
 	request_ip = request.META['REMOTE_ADDR']
-	if request_ip is None: #LIBDRS-8313 temporary hack
-		request_ip = "128.103.229.19"
+	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)
@@ -267,6 +267,7 @@ def delete(request, document_id):
 # Pull METS, MODS or HUAM JSON, rerun conversion script, and store in db
 def refresh(request, document_id):
 	request_ip = request.META['REMOTE_ADDR']
+	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)
@@ -300,6 +301,7 @@ def refresh(request, document_id):
 # Pull all METS, MODS or HUAM JSON, rerun conversion script, and store in db
 def refresh_by_source(request, source):
 	request_ip = request.META['REMOTE_ADDR']
+	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -243,6 +243,8 @@ def manifest(request, document_id):
 # Delete any document from db
 def delete(request, document_id):
 	request_ip = request.META['REMOTE_ADDR']
+	if request_ip is None: #LIBDRS-8313 temporary hack
+		request_ip = "128.103.229.19"
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -163,7 +163,6 @@ def view(request, view_type, document_id):
 		else:
 			mfwobject = {"loadedManifest": uri,
 				"viewType": parts["view"] }
-
 			if view_type == "view-dev": #mirador 3 preview
 			  mfwobject = {"loadedManifest": uri,
 						   "thumbnailNavigationPosition": "far-bottom"}

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -39,7 +39,6 @@ sources = {"drs": "mets", "via": "mods", "hollis": "mods", "huam" : "huam", "ext
 
 def index(request, source=None):
 	request_ip = request.META['REMOTE_ADDR']
-	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)
@@ -243,7 +242,6 @@ def manifest(request, document_id):
 # Delete any document from db
 def delete(request, document_id):
 	request_ip = request.META['REMOTE_ADDR']
-	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)
@@ -266,7 +264,6 @@ def delete(request, document_id):
 # Pull METS, MODS or HUAM JSON, rerun conversion script, and store in db
 def refresh(request, document_id):
 	request_ip = request.META['REMOTE_ADDR']
-	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)
@@ -300,7 +297,6 @@ def refresh(request, document_id):
 # Pull all METS, MODS or HUAM JSON, rerun conversion script, and store in db
 def refresh_by_source(request, source):
 	request_ip = request.META['REMOTE_ADDR']
-	request_ip = "128.103.229.19" #LIBDRS-8313
 	if not all_matching_cidrs(request_ip, IIIF_MGMT_ACL):
 	  if not all_matching_cidrs(get_xfwd_ip(request), IIIF_MGMT_ACL):
 		  return HttpResponse("Access Denied.", status=403)

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -162,6 +162,7 @@ def view(request, view_type, document_id):
 		else:
 			mfwobject = {"loadedManifest": uri,
 				"viewType": parts["view"] }
+				
 			if view_type == "view-dev": #mirador 3 preview
 			  mfwobject = {"loadedManifest": uri,
 						   "thumbnailNavigationPosition": "far-bottom"}


### PR DESCRIPTION
What this does: this restores table of contents rendering for pds objects with complex structures.  a bug in logic was introduced when remediating from python 2 to python 3. 

jira ticket: https://jira.huit.harvard.edu/browse/LIBDRS-8313

unit testing: no

how to test: this code is in qa and dev.  

qa:
https://iiif-qa.lib.harvard.edu/manifests/refresh/drs:401823303
then
https://iiif-qa.lib.harvard.edu/manifests/view/drs:401823303
to confirm that object shows nested sections

https://iiif-qa.lib.harvard.edu/manifests/refresh/drs:400016595
then
https://iiif-qa.lib.harvard.edu/manifests/view/drs:400016595
to confirm that object shows toc

dev: 
https://iiif-dev.lib.harvard.edu/manifests/refresh/drs:400018200
then
https://iiif-dev.lib.harvard.edu/manifests/view/drs:400018200  
to see object w/ table of contents

https://iiif-dev.lib.harvard.edu/manifests/refresg/drs:400013528
then
https://iiif-dev.lib.harvard.edu/manifests/view/drs:400013528
to confirm valid table of contents - you should see one section per page

other objects in qa and dev can be tested this way.