### PR TITLE
LIBDRS-8366 fix loading of IDS: images

### DIFF
--- a/manifests/static/manifests/ids-prod.js
+++ b/manifests/static/manifests/ids-prod.js
@@ -182,8 +182,8 @@ $(function() {
             last_idx = parts.length - 1,
 	    drs_match = parts[last_idx].match(/drs:(\d+)/),
             drs_id = drs_match && drs_match[1],
-            ids_match = parts[last_idx].match(/ids:(\d+)/),
-            ids_id = ids_match && ids_match[1],
+            /*ids_match = parts[last_idx].match(/ids:(\d+)/),
+            ids_id = ids_match && ids_match[1],*/
             focusType = mirWindow.currentImageMode,
             n = mirWindow.focusModules[focusType].currentImgIndex + 1;
         if (mirWindow.id === omit_id) {
@@ -192,9 +192,9 @@ $(function() {
         else if (drs_match) {
           return 'drs:' + drs_id + '$' + n + ftype_alias[focusType];
         }
-        else if (ids_match) {
+        /*else if (ids_match) {
           return 'ids:' + ids_id + '$' + n + ftype_alias[focusType];
-        }
+        }*/
         else {
           return "ext:" + Base64.encode(uri).replace(/\+/g, '-').replace(/\//g, '_') + '$' + n + ftype_alias[focusType];
         }

--- a/manifests/static/manifests/ids-prod.js
+++ b/manifests/static/manifests/ids-prod.js
@@ -182,6 +182,8 @@ $(function() {
             last_idx = parts.length - 1,
 	    drs_match = parts[last_idx].match(/drs:(\d+)/),
             drs_id = drs_match && drs_match[1],
+            ids_match = parts[last_idx].match(/ids:(\d+)/),
+            ids_id = ids_match && ids_match[1],
             focusType = mirWindow.currentImageMode,
             n = mirWindow.focusModules[focusType].currentImgIndex + 1;
         if (mirWindow.id === omit_id) {
@@ -189,6 +191,9 @@ $(function() {
         }
         else if (drs_match) {
           return 'drs:' + drs_id + '$' + n + ftype_alias[focusType];
+        }
+        else if (ids_match) {
+          return 'ids:' + ids_id + '$' + n + ftype_alias[focusType];
         }
         else {
           return "ext:" + Base64.encode(uri).replace(/\+/g, '-').replace(/\//g, '_') + '$' + n + ftype_alias[focusType];

--- a/manifests/static/manifests/ids-prod.js
+++ b/manifests/static/manifests/ids-prod.js
@@ -182,8 +182,6 @@ $(function() {
             last_idx = parts.length - 1,
 	    drs_match = parts[last_idx].match(/drs:(\d+)/),
             drs_id = drs_match && drs_match[1],
-            /*ids_match = parts[last_idx].match(/ids:(\d+)/),
-            ids_id = ids_match && ids_match[1],*/
             focusType = mirWindow.currentImageMode,
             n = mirWindow.focusModules[focusType].currentImgIndex + 1;
         if (mirWindow.id === omit_id) {
@@ -192,9 +190,6 @@ $(function() {
         else if (drs_match) {
           return 'drs:' + drs_id + '$' + n + ftype_alias[focusType];
         }
-        /*else if (ids_match) {
-          return 'ids:' + ids_id + '$' + n + ftype_alias[focusType];
-        }*/
         else {
           return "ext:" + Base64.encode(uri).replace(/\+/g, '-').replace(/\//g, '_') + '$' + n + ftype_alias[focusType];
         }

--- a/manifests/templates/manifests/ids.html
+++ b/manifests/templates/manifests/ids.html
@@ -13,8 +13,9 @@
   <link rel="stylesheet" type="text/css" href="{% static 'canvas/canvasLink.css' %}">
   <link rel="icon" type="image/x-icon" href="https://library.harvard.edu/sites/default/files/favicon_0.ico"/>
   <!-- <link rel="stylesheet" type="text/css" href="{% static 'saveimage/jquery-ui-smootheness.css' %}"> -->
-  <!-- link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css" -->
+  <link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
   <script src="{% static 'manifests/prod/mirador.js' %}"></script>
+  <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js" integrity="sha256-xNjb53/rY+WmG+4L6tTl9m6PpqknWZvRt0rO1SRnJzw=" crossorigin="anonymous"></script>
   <script src="{% static 'base64.min.js' %}"></script>
   <!-- jqwidgets for search and related links -->
   <script src="{% static 'jqwidgets/jqxcore.js' %}"></script>

--- a/manifests/templates/manifests/ids.html
+++ b/manifests/templates/manifests/ids.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" type="text/css" href="{% static 'canvas/canvasLink.css' %}">
   <link rel="icon" type="image/x-icon" href="https://library.harvard.edu/sites/default/files/favicon_0.ico"/>
   <!-- <link rel="stylesheet" type="text/css" href="{% static 'saveimage/jquery-ui-smootheness.css' %}"> -->
-  <link rel="stylesheet" type="text/css" href="//code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css">
+  <link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css" >
   <script src="{% static 'manifests/prod/mirador.js' %}"></script>
   <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js" integrity="sha256-xNjb53/rY+WmG+4L6tTl9m6PpqknWZvRt0rO1SRnJzw=" crossorigin="anonymous"></script>
   <script src="{% static 'base64.min.js' %}"></script>

--- a/manifests/templates/manifests/ids.html
+++ b/manifests/templates/manifests/ids.html
@@ -13,7 +13,7 @@
   <link rel="stylesheet" type="text/css" href="{% static 'canvas/canvasLink.css' %}">
   <link rel="icon" type="image/x-icon" href="https://library.harvard.edu/sites/default/files/favicon_0.ico"/>
   <!-- <link rel="stylesheet" type="text/css" href="{% static 'saveimage/jquery-ui-smootheness.css' %}"> -->
-  <link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css" >
+  <!-- link rel="stylesheet" type="text/css" href="https://code.jquery.com/ui/1.11.4/themes/smoothness/jquery-ui.css" -->
   <script src="{% static 'manifests/prod/mirador.js' %}"></script>
   <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js" integrity="sha256-xNjb53/rY+WmG+4L6tTl9m6PpqknWZvRt0rO1SRnJzw=" crossorigin="anonymous"></script>
   <script src="{% static 'base64.min.js' %}"></script>

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -166,15 +166,15 @@ def view(request, view_type, document_id):
 			  mfwobject = {"loadedManifest": uri,
 						   "thumbnailNavigationPosition": "far-bottom"}
 
-			# Load manifest as JSON, get sequence info, use canvasID to page into object
-			mfjson = json.loads(response)["sequences"][0]["canvases"]
-			try:
-				if parts["seq"] and 0 < parts["seq"] <= len(mfjson):
-					mfwobject["canvasID"] = mfjson[parts["seq"] - 1]["@id"]
-			except(ValueError):
-				pass
+		# Load manifest as JSON, get sequence info, use canvasID to page into object
+		mfjson = json.loads(response)["sequences"][0]["canvases"]
+		try:
+			if parts["seq"] and 0 < parts["seq"] <= len(mfjson):
+				mfwobject["canvasID"] = mfjson[parts["seq"] - 1]["@id"]
+		except(ValueError):
+			pass
 
-			manifests_wobjects.append(json.dumps(mfwobject))
+		manifests_wobjects.append(json.dumps(mfwobject))
 
 	if len(manifests_data) > 0:
 		view_locals = {'path_data':          path_data,


### PR DESCRIPTION
What this does: this restores table of contents rendering for pds objects with complex structures. a bug in logic was introduced when remediating from python 2 to python 3.

jira ticket: https://jira.huit.harvard.edu/browse/LIBDRS-8366

unit testing: no

how to test: this code is in qa and dev.

qa:
https://iiif-qa.lib.harvard.edu/manifests/view/ids:400751764

dev
https://iiif-dev.lib.harvard.edu/manifests/view/ids:400000203

other ids images in qa and dev can be tested this way.