### PR TITLE
change all /usr/bin/python references to /usr/bin/python3

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/manifests/ams.py
+++ b/manifests/ams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import requests
 import re, json

--- a/manifests/huam.py
+++ b/manifests/huam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import json, sys
 import urllib.request

--- a/manifests/ids.py
+++ b/manifests/ids.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import json, sys
 import requests

--- a/manifests/mets.py
+++ b/manifests/mets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from lxml import etree
 import json, sys, re

--- a/manifests/mods.py
+++ b/manifests/mods.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from lxml import etree
 import json, sys

--- a/manifests/webclient.py
+++ b/manifests/webclient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import urllib
 


### PR DESCRIPTION
this is a configuration change to make sure that python2 isn't being loaded and causing a "multiple interpreters being loaded" error.

to test, 

go to https://pds-qa.lib.harvard.edu/pds/view/402010832

you should see the harvard viewer screen.