### PR TITLE
LTSK8S-373: logging to stdout for k8s

### DIFF
--- a/manifests/views.py
+++ b/manifests/views.py
@@ -32,7 +32,7 @@ IIIF_MGMT_ACL = (environ.get("IIIF_MGMT_ACL","128.103.151.0/24,10.34.5.254,10.40
 CORS_WHITELIST = (environ.get("CORS_WHITELIST", "http://harvard.edu")).split(',')
 IIIF_MANIFEST_HOST = environ.get("IIIF_MANIFEST_HOST")
 CAPTION_API_URL = (environ.get("CAPTION_API","http://ids.lib.harvard.edu:8080/ids/lookup?id="))
-VERSION = "v1.6.41"
+VERSION = "v1.6.43"
 
 sources = {"drs": "mets", "via": "mods", "hollis": "mods", "huam" : "huam", "ext": "ext", "ids": "ids" }
 

--- a/metadata_server/settings.py
+++ b/metadata_server/settings.py
@@ -173,14 +173,14 @@ LOGGING = {
         'file': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
-            'filename': os.path.join(BASE_DIR, 'debug.log'),
+            'filename': os.environ.get('LOG_FILE', '/proc/1/fd/1')
         },
     },
     'loggers': {
         'manifests': {
             'handlers': ['file'],
             'level': 'DEBUG',
-            'propagate': True,
+            'propagate': True
         },
     },
 }


### PR DESCRIPTION
**LTSK8S-373: logging to stdout for k8s.**
* * *

**JIRA Ticket**: https://at-harvard.atlassian.net/browse/LTSK8S-373


# What does this Pull Request do?
logs to stdout for k8s compliance

# How should this be tested?
@jaj561 can confirm that this is logging in k8s by going to https://K8S_BASE_URL/manifests/view/drs:400008439

# Test coverage
Yes/No: Are changes in this pull-request covered by:
- unit tests? n
- integration tests? n

# Interested parties
Tag (@ mention) interested parties: @awoods @jaj561 
