### PR TITLE
v1.6.44 - remove 'Access-Control-Allow-Origin: *'

### DIFF
--- a/manifests/views.py
+++ b/manifests/views.py
@@ -32,7 +32,7 @@ IIIF_MGMT_ACL = (environ.get("IIIF_MGMT_ACL","128.103.151.0/24,10.34.5.254,10.40
 CORS_WHITELIST = (environ.get("CORS_WHITELIST", "http://harvard.edu")).split(',')
 IIIF_MANIFEST_HOST = environ.get("IIIF_MANIFEST_HOST")
 CAPTION_API_URL = (environ.get("CAPTION_API","http://ids.lib.harvard.edu:8080/ids/lookup?id="))
-VERSION = "v1.6.43"
+VERSION = "v1.6.44"
 
 sources = {"drs": "mets", "via": "mods", "hollis": "mods", "huam" : "huam", "ext": "ext", "ids": "ids" }
 
@@ -428,7 +428,7 @@ def add_headers(response, request):
 	#   response["Access-Control-Allow-Origin"] = "*"
 	#response["Access-Control-Allow-Origin"] = "http://harvard.edu/"
 	#response["Access-Control-Allow-Credentials"] = "true"
-	response["Access-Control-Allow-Origin"] = "*"
+	#response["Access-Control-Allow-Origin"] = "*"
 	response["Content-Type"] = "application/ld+json"
 	return response
 


### PR DESCRIPTION
jira: https://at-harvard.atlassian.net/browse/LTSK8S-1413

this pr removes an extra cors header from the http response.

to test (in qa):

1. go to https://mirador-dev.netlify.app/__tests__/integration/mirador/
2. click on the blue "+" button in the top left hand corner
3. click on the "add resource" button in the bottom right hand corner
4. paste "https://iiif-qa.lib.harvard.edu/manifests/ids:401119420" in the "resource location" input field and then press the add button
5. you should then see a manifest from Harvard University at the top of the manifest list. you should see the harvard logo on the right and a thumbnail of cats in boxes on the left. 

cc: @awoods 