### PR TITLE
Ltsdandi-98: Remove vim, gcc, git from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV APP_LOCATION_LOC=${APP_LOCATION}
 
 RUN DEBIAN_FRONTEND=non-interactive && \
     apt-get update -y && \
-    apt-get install -y curl git && \
+    apt-get install -y git && \
     groupadd -g ${APP_ID_NUMBER} ${APP_ID_NAME} && \
     useradd -u ${APP_ID_NUMBER} -g www-data -m -d /home/${APP_ID_NAME} -s /sbin/false ${APP_ID_NAME} && \
     cd /home/${APP_ID_NAME} && \
@@ -42,7 +42,7 @@ COPY requirements.txt /root/requirements.txt
 RUN cd /root && \
     apt-get update -y && \
     apt-get upgrade -y && \
-    apt-get install -y libffi-dev locales libcap2-bin apache2 libapache2-mod-wsgi-py3 curl pkg-config cmake unzip libxml2-dev libxslt1-dev python3 python3-pip build-essential supervisor ca-certificates && \
+    apt-get install -y libffi-dev locales libcap2-bin apache2 libapache2-mod-wsgi-py3 pkg-config cmake unzip libxml2-dev libxslt1-dev python3 python3-pip build-essential supervisor ca-certificates && \
     pip3 install pip-tools && \
     apt-get clean && \
     a2enmod rewrite && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Chip Goines <chip_goines@harvard.edu>
 # Borrowed Heavily from Default Docker File for Loris.
 
 # Initialize Ubuntu environment with required packages.
-ARG APP_VERSION='v1.5.3'
+ARG APP_VERSION='v1.6.45'
 ARG APP_LOCATION='https://github.com/harvard-library/metadata_server.git'
 
 ENV APP_NAME="metadata_server"

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ RUN cd /root && \
     pip3 install pip-tools && \
     apt-get clean && \
     a2enmod rewrite && \
-    apt-get remove -y gcc && \
     groupadd -g ${APP_ID_NUMBER} ${APP_ID_NAME} && \
     useradd -u ${APP_ID_NUMBER} -g www-data -m -d /home/${APP_ID_NAME} -s /sbin/false ${APP_ID_NAME} && \
     chown -R ${APP_ID_NAME}:www-data /var/log/supervisor && \
@@ -61,6 +60,7 @@ COPY supervisor /etc/supervisor/
 COPY --from=builder --chown=ids:www-data /home/app/appbuild /home/ids/appbuild
 RUN mv /home/ids/appbuild /home/ids/${APP_NAME} && \
     cd /home/ids/${APP_NAME} && pip3 install -r /root/requirements.txt && \
+    apt-get remove -y gcc && \
     sed -i 's/USER=www-data/USER=${APP_ID_NAME}/' /etc/apache2/envvars
 
 WORKDIR /home/${APP_ID_NAME}/${APP_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN cd /root && \
     pip3 install pip-tools && \
     apt-get clean && \
     a2enmod rewrite && \
+    apt-get remove -y gcc && \
     groupadd -g ${APP_ID_NUMBER} ${APP_ID_NAME} && \
     useradd -u ${APP_ID_NUMBER} -g www-data -m -d /home/${APP_ID_NAME} -s /sbin/false ${APP_ID_NAME} && \
     chown -R ${APP_ID_NAME}:www-data /var/log/supervisor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN DEBIAN_FRONTEND=non-interactive && \
     sed -i '/uWSGI/c\uwsgi' /home/app/appbuild/requirements.txt && \
     curl -o /home/app/appbuild/global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
 
-FROM artifactory.huit.harvard.edu/lts/apache_base:latest
+FROM artifactory.huit.harvard.edu/lts/apache_base:1.0.0
 
 ENV APP_NAME="metadata_server"
 ENV APP_ID_NUMBER=54422

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -32,7 +32,7 @@ IIIF_MGMT_ACL = (environ.get("IIIF_MGMT_ACL","128.103.151.0/24,10.34.5.254,10.40
 CORS_WHITELIST = (environ.get("CORS_WHITELIST", "http://harvard.edu")).split(',')
 IIIF_MANIFEST_HOST = environ.get("IIIF_MANIFEST_HOST")
 CAPTION_API_URL = (environ.get("CAPTION_API","http://ids.lib.harvard.edu:8080/ids/lookup?id="))
-VERSION = "v1.6.44"
+VERSION = "v1.6.45"
 
 sources = {"drs": "mets", "via": "mods", "hollis": "mods", "huam" : "huam", "ext": "ext", "ids": "ids" }
 


### PR DESCRIPTION
Remove vim, gcc, git from Dockerfiles

this has been pushed to dev and can be tested there. to test:

1) enter a shell from rancher
2) try executing git, vi, or gcc. you should see output like this:

```
ids@iiif-79b645cf48-7lnnm:~/metadata_server$ gcc
bash: gcc: command not found
ids@iiif-79b645cf48-7lnnm:~/metadata_server$ g++
bash: g++: command not found
ids@iiif-79b645cf48-7lnnm:~/metadata_server$ git
bash: git: command not found
ids@iiif-79b645cf48-7lnnm:~/metadata_server$ vi
bash: vi: command not found
ids@iiif-79b645cf48-7lnnm:~/metadata_server$ vim
bash: vim: command not found
```